### PR TITLE
Replaced NotifyPropertyChanged with Dependency Properties

### DIFF
--- a/1.0/FirstFloor.ModernUI/Shared/Presentation/Displayable.cs
+++ b/1.0/FirstFloor.ModernUI/Shared/Presentation/Displayable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace FirstFloor.ModernUI.Presentation
 {
@@ -10,24 +11,24 @@ namespace FirstFloor.ModernUI.Presentation
     /// Provides a base implementation for objects that are displayed in the UI.
     /// </summary>
     public abstract class Displayable
-        : NotifyPropertyChanged
+        : DependencyObject
     {
-        private string displayName;
+        /// <summary>
+        /// The display name property
+        /// </summary>
+        public static readonly DependencyProperty DisplayNameProperty = DependencyProperty.Register(
+            "DisplayName", typeof (string), typeof (Displayable), new PropertyMetadata(default(string)));
 
         /// <summary>
         /// Gets or sets the display name.
         /// </summary>
-        /// <value>The display name.</value>
+        /// <value>
+        /// The display name.
+        /// </value>
         public string DisplayName
         {
-            get { return this.displayName; }
-            set
-            {
-                if (this.displayName != value) {
-                    this.displayName = value;
-                    OnPropertyChanged("DisplayName");
-                }
-            }
+            get { return (string) GetValue(DisplayNameProperty); }
+            set { SetValue(DisplayNameProperty, value); }
         }
     }
 }

--- a/1.0/FirstFloor.ModernUI/Shared/Presentation/Link.cs
+++ b/1.0/FirstFloor.ModernUI/Shared/Presentation/Link.cs
@@ -6,28 +6,30 @@ using System.Threading.Tasks;
 
 namespace FirstFloor.ModernUI.Presentation
 {
+    using System.Windows;
+
     /// <summary>
     /// Represents a displayable link.
     /// </summary>
     public class Link
         : Displayable
     {
-        private Uri source;
+        /// <summary>
+        /// The source property
+        /// </summary>
+        public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+            "Source", typeof (Uri), typeof (Link), new PropertyMetadata(default(Uri)));
 
         /// <summary>
-        /// Gets or sets the source uri.
+        /// Gets or sets the source.
         /// </summary>
-        /// <value>The source.</value>
+        /// <value>
+        /// The source.
+        /// </value>
         public Uri Source
         {
-            get { return this.source; }
-            set
-            {
-                if (this.source != value) {
-                    this.source = value;
-                    OnPropertyChanged("Source");
-                }
-            }
+            get { return (Uri) GetValue(SourceProperty); }
+            set { SetValue(SourceProperty, value); }
         }
     }
 }

--- a/1.0/FirstFloor.ModernUI/Shared/Presentation/LinkGroup.cs
+++ b/1.0/FirstFloor.ModernUI/Shared/Presentation/LinkGroup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace FirstFloor.ModernUI.Presentation
 {
@@ -12,9 +13,13 @@ namespace FirstFloor.ModernUI.Presentation
     public class LinkGroup
         : Displayable
     {
-        private string groupKey;
-        private Link selectedLink;
         private LinkCollection links = new LinkCollection();
+
+        /// <summary>
+        /// The group key property
+        /// </summary>
+        public static readonly DependencyProperty GroupKeyProperty = DependencyProperty.Register(
+            "GroupKey", typeof (string), typeof (LinkGroup), new PropertyMetadata(default(string)));
 
         /// <summary>
         /// Gets or sets the key of the group.
@@ -25,15 +30,15 @@ namespace FirstFloor.ModernUI.Presentation
         /// </remarks>
         public string GroupKey
         {
-            get { return this.groupKey; }
-            set
-            {
-                if (this.groupKey != value) {
-                    this.groupKey = value;
-                    OnPropertyChanged("GroupKey");
-                }
-            }
+            get { return (string) GetValue(GroupKeyProperty); }
+            set { SetValue(GroupKeyProperty, value); }
         }
+
+        /// <summary>
+        /// The selected link property
+        /// </summary>
+        public static readonly DependencyProperty SelectedLinkProperty = DependencyProperty.Register(
+            "SelectedLink", typeof (Link), typeof (LinkGroup), new PropertyMetadata(default(Link)));
 
         /// <summary>
         /// Gets or sets the selected link in this group.
@@ -41,14 +46,8 @@ namespace FirstFloor.ModernUI.Presentation
         /// <value>The selected link.</value>
         internal Link SelectedLink
         {
-            get { return this.selectedLink; }
-            set
-            {
-                if (this.selectedLink != value) {
-                    this.selectedLink = value;
-                    OnPropertyChanged("SelectedLink");
-                }
-            }
+            get { return (Link) GetValue(SelectedLinkProperty); }
+            set { SetValue(SelectedLinkProperty, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
Replaced NotifyPropertyChanged with Dependency Properties on Displayable and children.
This is more consistent with the idea that views use dependency properties whereas view-models use notify property changed.