### PR TITLE
Enable Binding of DisplayName of Link and LinkGroup for i18n purposes

### DIFF
--- a/1.0/FirstFloor.ModernUI/Shared/Presentation/Displayable.cs
+++ b/1.0/FirstFloor.ModernUI/Shared/Presentation/Displayable.cs
@@ -1,32 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Windows;
 
 namespace FirstFloor.ModernUI.Presentation
 {
     /// <summary>
-    /// Provides a base implementation for objects that are displayed in the UI.
+    ///     Provides a base implementation for objects that are displayed in the UI.
     /// </summary>
     public abstract class Displayable
         : NotifyPropertyChanged
     {
-        private string displayName;
 
         /// <summary>
-        /// Gets or sets the display name.
+        ///     DependencyProperty for DisplayName to be able to bind the property
+        /// </summary>
+        public static readonly DependencyProperty DisplayNameProperty = DependencyProperty.Register("DisplayName", typeof(string), typeof(Displayable), new PropertyMetadata(""));
+
+        /// <summary>
+        ///     Gets or sets the display name.
         /// </summary>
         /// <value>The display name.</value>
         public string DisplayName
         {
-            get { return this.displayName; }
+            get { return (string)GetValue(DisplayNameProperty); }
             set
             {
-                if (this.displayName != value) {
-                    this.displayName = value;
-                    OnPropertyChanged("DisplayName");
-                }
+                SetValue(DisplayNameProperty, value);
             }
         }
     }

--- a/1.0/FirstFloor.ModernUI/Shared/Presentation/Link.cs
+++ b/1.0/FirstFloor.ModernUI/Shared/Presentation/Link.cs
@@ -1,33 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Windows;
 
 namespace FirstFloor.ModernUI.Presentation
 {
     /// <summary>
-    /// Represents a displayable link.
+    ///     Represents a displayable link.
     /// </summary>
     public class Link
         : Displayable
     {
-        private Uri source;
+        /// <summary>
+        ///     DependencyProperty for Source to be able to bind the value
+        /// </summary>
+        public static readonly DependencyProperty SourceProperty = DependencyProperty.Register("Source", typeof(Uri), typeof(Link), new PropertyMetadata(null));
 
         /// <summary>
-        /// Gets or sets the source uri.
+        ///     Gets or sets the source uri.
         /// </summary>
         /// <value>The source.</value>
         public Uri Source
         {
-            get { return this.source; }
-            set
-            {
-                if (this.source != value) {
-                    this.source = value;
-                    OnPropertyChanged("Source");
-                }
-            }
+            get { return (Uri) GetValue(SourceProperty); }
+            set { SetValue(SourceProperty, value); }
         }
     }
 }

--- a/1.0/FirstFloor.ModernUI/Shared/Presentation/NotifyPropertyChanged.cs
+++ b/1.0/FirstFloor.ModernUI/Shared/Presentation/NotifyPropertyChanged.cs
@@ -1,48 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
+﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+using System.Windows;
 
 namespace FirstFloor.ModernUI.Presentation
 {
     /// <summary>
-    /// The base implementation of the INotifyPropertyChanged contract.
+    ///     The base implementation of the INotifyPropertyChanged contract.
     /// </summary>
     public abstract class NotifyPropertyChanged
-        : INotifyPropertyChanged
+        : DependencyObject, INotifyPropertyChanged
     {
         /// <summary>
-        /// Occurs when a property value changes.
+        ///     Occurs when a property value changes.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
-        /// Raises the PropertyChanged event.
+        ///     Raises the PropertyChanged event.
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
         protected virtual void OnPropertyChanged(string propertyName)
         {
-            var handler = this.PropertyChanged;
-            if (handler != null) {
+            var handler = PropertyChanged;
+            if (handler != null)
+            {
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
         }
 
 #if !NET4
         /// <summary>
-        /// Updates specified value, and raises the <see cref="PropertyChanged"/> event when the value has changed.
+        ///     Updates specified value, and raises the <see cref="PropertyChanged" /> event when the value has changed.
         /// </summary>
         /// <typeparam name="T">The type of the value.</typeparam>
         /// <param name="storage">The current stored value</param>
         /// <param name="value">The new value</param>
         /// <param name="propertyName">The optional property name, automatically set to caller member name when not set.</param>
         /// <returns>Indicates whether the value has changed.</returns>
-        protected bool Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
+        protected bool Set<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
-            if (!object.Equals(storage, value)) {
+            if (!Equals(storage, value))
+            {
                 storage = value;
                 OnPropertyChanged(propertyName);
                 return true;


### PR DESCRIPTION
Added DependencyObject class to inheritance hierarchy of Displayable to be able to register DependencyProperties in Link and LinkGroup to enable binding of the DisplayName of both for internationalization.
